### PR TITLE
fix(platform): fix type of global

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ interface Platform {
   /**
   * The runtime environment's global.
   */
-  global: Object,
+  global: any,
   /**
   * A function wich does nothing.
   */


### PR DESCRIPTION
`PLATFORM.global.document` is an error because `document` is not found in `Object`. Switching to `any` fixes that.
