### PR TITLE
fix(AggregateError): better surface inner error information

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,26 @@ export function AggregateError(message: string, innerError?: Error, skipIfAlread
       return innerError;
     }
 
-    if (innerError.stack) {
-      message += `\n------------------------------------------------\ninner error: ${innerError.stack}`;
+    const separator = '\n------------------------------------------------\n';
+
+    message += `${separator}Inner Error:\n`;
+
+    if (typeof(innerError) === 'string' ) {
+      message += `Message: ${innerError}`;
+    } else {
+      if (innerError.message) {
+        message += `Message: ${innerError.message}`;
+      } else {
+        message += `Unknown Inner Error Type. Displaying Inner Error as JSON:\n ${JSON.stringify(innerError, null, '  ')}`;
+      }
+
+      if (innerError.stack) {
+        message += `\nInner Error Stack:\n${innerError.stack}`;
+        message += '\nEnd Inner Error Stack';
+      }
     }
+
+    message += separator;
   }
 
   let e = new Error(message);


### PR DESCRIPTION
This change is a compromise that provides the simplest way to surface error message information across browsers. We will now display the inner error message as part of the outer error message. Previously we only added the "innerError" property to the Error instance created in this function, but no browser I tested allows for viewing non-built in properties.

This solution works well in Chrome and Firefox and IE11. Edge ignores the newline characters, even if I do `\r\n`. I'll file a bug with the Edge Developer tools team about that. 

Sample screenshots:
**Chrome**
- Throwing a string
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763082/656acc8c-0959-11e6-9b8e-6ed9eb52ee20.png)
- Throw an Error 
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763104/e9fadb54-0959-11e6-83d4-55cf47dd6da4.png)
- Unknown Error Type
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763060/ce94ff3a-0958-11e6-9f3b-d992114e7798.png)

**Firefox**
- Throwing a string
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763092/a23e68bc-0959-11e6-9676-75b05e0e177c.png)
- Throw an Error 
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763106/f429377e-0959-11e6-9da8-eda9a3a00f39.png)
- Unknown Error Type
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763064/eecbbf96-0958-11e6-8c6e-5ba9e8b75fdc.png)

**Edge**
- Throwing a string
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763097/c5c4515c-0959-11e6-82bc-1a609b0f3d47.png)
- Throw an Error 
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763102/dcd7e2d2-0959-11e6-9c06-5a810d112588.png)
- Unknown Error Type
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763071/15a68f7e-0959-11e6-9fb6-4e8c07f5b2a9.png)

**IE 11**
- Throwing a string
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763089/7bf82dd2-0959-11e6-8988-4373b8980508.png)
- Throw an Error 
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763108/0d030e5a-095a-11e6-8cdd-169b67999844.png)
- Unknown Error Type
  ![image](https://cloud.githubusercontent.com/assets/9885322/14763076/37a3ff9e-0959-11e6-8c7d-61577ecdeceb.png)

One other nice thing is that Chrome splits error messages on a line break, and only displays the first line with the option to expand the error message, so the user can expand the error message to see the error message. It's a nice UX that I wish the other browsers would implement.
![image](https://cloud.githubusercontent.com/assets/9885322/14763117/4fcb5b16-095a-11e6-9d56-cf2cee5a9f8b.png)
Clicking the ellipses will show the inner error.
