### PR TITLE
feat(index): move isInitialized to aurelia-pal

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,11 +95,11 @@ interface Platform {
   /**
   * The runtime's location API.
   */
-  location: Object;
+  location: typeof window.location;
   /**
   * The runtime's history API.
   */
-  history: Object;
+  history: typeof window.history;
   /**
   * The runtime's performance API
   */
@@ -113,7 +113,7 @@ interface Platform {
   /**
   * The runtime's XMLHttpRequest API.
   */
-  XMLHttpRequest: XMLHttpRequest;
+  XMLHttpRequest: typeof XMLHttpRequest;
   /**
   * Iterate all modules loaded by the script loader.
   * @param callback A callback that will receive each module id along with the module object. Return true to end enumeration.
@@ -165,11 +165,11 @@ interface Dom {
   /**
   * The global DOM Element type.
   */
-  Element: Element;
+  Element: typeof Element;
   /**
   * The global DOM SVGElement type.
   */
-  SVGElement: SVGElement;
+  SVGElement: typeof SVGElement;
   /**
   * A key representing a DOM boundary.
   */

--- a/src/index.js
+++ b/src/index.js
@@ -306,12 +306,16 @@ interface Dom {
 * The singleton instance of the Dom API.
 */
 export const DOM: Dom = {};
-
+export let isInitialized = false;
 /**
 * Enables initializing a specific implementation of the Platform Abstraction Layer (PAL).
 * @param callback Allows providing a callback which configures the three PAL singletons with their platform-specific implementations.
 */
 export function initializePAL(callback: (platform: Platform, feature: Feature, dom: Dom) => void): void {
+  if (isInitialized) {
+    return;
+  }
+  isInitialized = true;
   if (typeof Object.getPropertyDescriptor !== 'function') {
     Object.getPropertyDescriptor = function(subject, name) {
       let pd = Object.getOwnPropertyDescriptor(subject, name);
@@ -325,4 +329,7 @@ export function initializePAL(callback: (platform: Platform, feature: Feature, d
   }
 
   callback(PLATFORM, FEATURE, DOM);
+}
+export function reset() {
+  isInitialized = false;
 }


### PR DESCRIPTION
It makes sense to have `isInitialized` in aurelia-pal, not in each individual `-pal` repository, otherwise you can initialize it multiple times with different PALs by mistake, which is probably not the desired behavior. I've added a `reset()` function just in case somebody wants to purposefully reinitialize PAL with a different version.

Related PRs for all PALs:

- https://github.com/aurelia/pal-browser/issues/14
- https://github.com/aurelia/pal-worker/issues/4
- https://github.com/aurelia/pal-nodejs/issues/20