### PR TITLE
fix(typings): reference to the loader interface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,11 @@ interface Platform {
   * @param capture Specifies whether the listener to be removed was registered as a capturing listener or not.
   */
   removeEventListener(eventName: string, callback: Function, capture?: boolean): void;
+
+  /**
+   * Reference to the Loader Class (set after the loader has been first imported)
+   */
+  Loader: any;
 }
 
 /**


### PR DESCRIPTION
Adds the PLATFORM.Loader reference (this is set by all the loaders, but wasn't defined on the PLATFORM interface).