### PR TITLE
feat(typings): add shorthand for moduleName's second parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ interface Platform {
    * @param options Optional options used during the static analysis that inform how to process the module.
    */
   moduleName(moduleName: string, options?: ModuleNameOptions): string;
+  moduleName(moduleName: string, chunk?: string): string;
 }
 
 /**


### PR DESCRIPTION
adds typings for "PAL.moduleName(moduleName, chunk?: string)" enabled by https://github.com/aurelia/webpack-plugin/pull/88

/ CC: @jods4 /